### PR TITLE
Export `CKDPriv`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export const getMasterKeyFromSeed = (seed: Hex): Keys => {
     };
 };
 
-const CKDPriv = ({ key, chainCode }: Keys, index: number): Keys => {
+export const CKDPriv = ({ key, chainCode }: Keys, index: number): Keys => {
     const indexBuffer = Buffer.allocUnsafe(4);
     indexBuffer.writeUInt32BE(index, 0);
 


### PR DESCRIPTION
It was not possible to store an intermediate derivation node (for example at bip44 account level) and then derive a deeper node from it (for example at bip44 address level) without storing the root key/seed/mnemonic. Exporting `CKDPriv` allows users of this package to do that.